### PR TITLE
Modified file path used to read/write macros to match original Spacer:

### DIFF
--- a/SpacerNET_Interface/Common/Macros.cs
+++ b/SpacerNET_Interface/Common/Macros.cs
@@ -75,7 +75,7 @@ namespace SpacerUnion.Common
             objWin = win;
 
             formConf = new ConfirmForm(this);
-            pathFile = Path.GetFullPath(@"../_work/tools/macros_spacernet.txt");
+            pathFile = Path.GetFullPath(@"../_work/tools/Macros.zmf");
 
             //ConsoleEx.WriteLineRed(pathFile);
 


### PR DESCRIPTION
- This isn't a big change, but it helps when you need to switch between Spacer & Spacer.NET and you want to have macros file compatible with each other.
- There's no reason why this shouldn't be done like this in the first place