### PR TITLE
Respect saved window positions on restart

### DIFF
--- a/SpacerNET_Interface/Common/ScreenUtils.cs
+++ b/SpacerNET_Interface/Common/ScreenUtils.cs
@@ -1,0 +1,18 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SpacerUnion.Common
+{
+    public static class ScreenUtils
+    {
+        public static Point ClampToVisibleScreen(Point loc, Size size)
+        {
+            var rect = new Rectangle(loc, size);
+            foreach (var screen in Screen.AllScreens)
+            {
+                if (screen.WorkingArea.IntersectsWith(rect)) return loc;
+            }
+            return new Point(100, 100);
+        }
+    }
+}

--- a/SpacerNET_Interface/Common/SpacerNET.cs
+++ b/SpacerNET_Interface/Common/SpacerNET.cs
@@ -283,72 +283,72 @@ namespace SpacerUnion
 
             if (Properties.Settings.Default.TreeWinLocation != null)
             {
-                objTreeWin.Location = Properties.Settings.Default.TreeWinLocation;
+                objTreeWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.TreeWinLocation, objTreeWin.Size);
             }
 
             if (Properties.Settings.Default.PartWinLocation != null)
             {
-                objectsWin.Location = Properties.Settings.Default.PartWinLocation;
+                objectsWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.PartWinLocation, objectsWin.Size);
             }
 
             if (Properties.Settings.Default.VobListWinLocation != null)
             {
-                vobList.Location = Properties.Settings.Default.VobListWinLocation;
+                vobList.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.VobListWinLocation, vobList.Size);
             }
 
             if (Properties.Settings.Default.PropWinLocation != null)
             {
-                propWin.Location = Properties.Settings.Default.PropWinLocation;
+                propWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.PropWinLocation, propWin.Size);
             }
 
 
             if (Properties.Settings.Default.InfoWinLocation != null)
             {
-                infoWin.Location = Properties.Settings.Default.InfoWinLocation;
+                infoWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.InfoWinLocation, infoWin.Size);
             }
 
 
             if (Properties.Settings.Default.SoundWinLocation != null)
             {
-                soundWin.Location = Properties.Settings.Default.SoundWinLocation;
+                soundWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.SoundWinLocation, soundWin.Size);
             }
 
             if (Properties.Settings.Default.GrassWinLocation != null)
             {
-                grassWin.Location = Properties.Settings.Default.GrassWinLocation;
+                grassWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.GrassWinLocation, grassWin.Size);
             }
 
             if (Properties.Settings.Default.MacrosWinLocation != null)
             {
-                macrosWin.Location = Properties.Settings.Default.MacrosWinLocation;
+                macrosWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.MacrosWinLocation, macrosWin.Size);
             }
 
             if (Properties.Settings.Default.MatFilterWinLocation != null)
             {
-                matFilterWin.Location = Properties.Settings.Default.MatFilterWinLocation;
+                matFilterWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.MatFilterWinLocation, matFilterWin.Size);
             }
 
             // pfx editor form
             if (Properties.Settings.Default.PFXEditorLocation != null)
             {
-                pfxWin.Location = Properties.Settings.Default.PFXEditorLocation;
+                pfxWin.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.PFXEditorLocation, pfxWin.Size);
             }
 
             // error reports form
             if (Properties.Settings.Default.ErrorWinLocation != null)
             {
-                errorForm.Location = Properties.Settings.Default.ErrorWinLocation;
+                errorForm.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.ErrorWinLocation, errorForm.Size);
             }
-            // UV form 
+            // UV form
             if (Properties.Settings.Default.UVWinLocation != null)
             {
-                uvForm.Location = Properties.Settings.Default.UVWinLocation;
+                uvForm.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.UVWinLocation, uvForm.Size);
             }
-            
+
             // Vob catalog form
             if (Properties.Settings.Default.VobCatalogWinLocation != null)
             {
-                vobCatForm.Location = Properties.Settings.Default.VobCatalogWinLocation;
+                vobCatForm.Location = ScreenUtils.ClampToVisibleScreen(Properties.Settings.Default.VobCatalogWinLocation, vobCatForm.Size);
             }
 
             //=======================================================================================

--- a/SpacerNET_Interface/SpacerNET_Interface.csproj
+++ b/SpacerNET_Interface/SpacerNET_Interface.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Common\Localizator.cs" />
     <Compile Include="Common\LocalizedStrings.cs" />
     <Compile Include="Common\Macros.cs" />
+    <Compile Include="Common\ScreenUtils.cs" />
     <Compile Include="Common\PFX_Editor\PFXEditorWin_Utils.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/SpacerNET_Interface/Windows/ObjTree.Designer.cs
+++ b/SpacerNET_Interface/Windows/ObjTree.Designer.cs
@@ -368,7 +368,7 @@
             this.Name = "ObjTree";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Objects list window";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ObjTree_FormClosing);
             this.Load += new System.EventHandler(this.ObjTree_Load);

--- a/SpacerNET_Interface/Windows/PFXEditorWin.Designer.cs
+++ b/SpacerNET_Interface/Windows/PFXEditorWin.Designer.cs
@@ -474,7 +474,7 @@
             this.Name = "PFXEditorWin";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "PFXEditorWin";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.PFXEditorWin_FormClosing);
             this.Load += new System.EventHandler(this.PFXEditorWin_Load);

--- a/SpacerNET_Interface/Windows/SearchErrorsForm.Designer.cs
+++ b/SpacerNET_Interface/Windows/SearchErrorsForm.Designer.cs
@@ -173,7 +173,7 @@ namespace SpacerUnion.Windows
             this.Name = "SearchErrorsForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "SearchErrorsForm";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SearchErrorsForm_FormClosing);
             this.Load += new System.EventHandler(this.SearchErrorsForm_Load);

--- a/SpacerNET_Interface/Windows/SoundWin.Designer.cs
+++ b/SpacerNET_Interface/Windows/SoundWin.Designer.cs
@@ -271,7 +271,7 @@
             this.Name = "SoundWin";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Sounds and music window";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SoundWin_FormClosing);
             this.Shown += new System.EventHandler(this.SoundWin_Shown);

--- a/SpacerNET_Interface/Windows/VobCatalog.Designer.cs
+++ b/SpacerNET_Interface/Windows/VobCatalog.Designer.cs
@@ -483,7 +483,7 @@ namespace SpacerUnion.Windows
             this.Name = "VobCatalogForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Vob Catalog";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.VobCatalogForm_FormClosing);
             this.Load += new System.EventHandler(this.VobCatalogForm_Load);


### PR DESCRIPTION
## Summary

Five forms had `StartPosition = CenterScreen` hardcoded in their `.Designer.cs` files, which silently overrode the existing `Properties.Settings` persistence already present in `SpacerNET.cs` for those windows. Result: every restart, the user's window arrangement was discarded and these five popped back to screen center.

Forms fixed (`Designer.cs` only — one line each, `CenterScreen` → `Manual`):
- `ObjTree`
- `PFXEditorWin`
- `SearchErrorsForm`
- `SoundWin`
- `VobCatalog`

## Multi-monitor safety

Also adds `Common/ScreenUtils.cs` with a small `ClampToVisibleScreen(Point, Size)` helper. Applied to all 14 `Location` restore sites in `SpacerNET.cs::Form_EnableInterface()`.

If a previously saved location no longer intersects any currently connected monitor (typical case: user disconnected a secondary display between sessions), the form now falls back to `(100, 100)` on the primary screen instead of opening off-screen and being unreachable.

## Not touched

Twelve other forms also have `StartPosition = CenterScreen` in their Designer (mostly modal dialogs like `ConfirmForm`, `RenameForm`, `LoadingForm`) but no persistence in Settings. Left alone — they should keep centering. If persistence for any of them is desired later, that's a separate change.

## Test plan

- [ ] Open Spacer, drag the five fixed windows to non-default positions, close, reopen → positions restored
- [ ] Disconnect secondary monitor between sessions where a window was on it → window snaps to `(100, 100)` on primary instead of going off-screen
- [ ] Modal dialogs (Confirm, Rename, Loading, etc.) still center as before