### PR TITLE
Add status bar to MainForm (world / polys / RAM)

### DIFF
--- a/SpacerNET_Interface/Common/Localizator.cs
+++ b/SpacerNET_Interface/Common/Localizator.cs
@@ -131,6 +131,8 @@ namespace SpacerUnion.Common
             SpacerNET.vobCatForm.UpdateLang();
             SpacerNET.vobCatForm.propsForm.UpdateLang();
             SpacerNET.uvForm.UpdateLang();
+
+            ToolTipManager.RetranslateAll();
         }
 
         [DllExport]

--- a/SpacerNET_Interface/Common/LocalizedStrings.cs
+++ b/SpacerNET_Interface/Common/LocalizedStrings.cs
@@ -962,6 +962,7 @@ namespace SpacerUnion.Common
             AddNewWord("WIN_GRASS_SET_ON_VOB", new List<string> { "Ставить объекты на вобы", "Set objects on vobs", "Objekte auf VOBs platzieren", "", "" });
             AddNewWord("MISC_SETTINGS_NO_WORK_CHECK", new List<string> { "Не проверять путь загружаемого ZEN (игнорировать папку _WORK)", "Don't check path while loading ZEN (ignore _WORK folder)", "Beim Laden von ZEN den Pfad nicht prüfen (Ordner _WORK ignorieren)", "", "" });
             AddNewWord("checkBoxAutoSave", new List<string> { "Автосохранение мира каждые 5 минут", "Auto-save world every 5 minutes", "Welt alle 5 Minuten automatisch speichern", "Automatyczny zapis świata co 5 minut", "Automatické ukládání světa každých 5 minut" });
+            AddNewWord("TT_AUTOSAVE_CHECKBOX", new List<string> { "Автосохранение каждые 5 минут в подпапку autosave/ (10 ротирующихся слотов)", "Auto-save every 5 minutes into autosave/ subfolder (10 rotating slots)", "Auto-Speichern alle 5 Minuten in autosave/-Unterordner (10 rotierende Slots)", "Automatyczne zapisywanie co 5 minut do podfolderu autosave/ (10 rotujących slotów)", "Automatické ukládání každých 5 minut do podsložky autosave/ (10 rotujících slotů)" });
 
             AddNewWord("UNION_VOB_UPSIDE_DOWN", new List<string> { "Воб успешно перевернут", "Vob has been flipped", "VOB wurde erfolgreich gedreht", "", "" });
             AddNewWord("KEYS_SET_UPSIDE_DOWN", new List<string> { "Перевернуть воб", "Flip vob upside down", "VOB drehen", "", "" });

--- a/SpacerNET_Interface/Common/LocalizedStrings.cs
+++ b/SpacerNET_Interface/Common/LocalizedStrings.cs
@@ -964,6 +964,10 @@ namespace SpacerUnion.Common
             AddNewWord("checkBoxAutoSave", new List<string> { "Автосохранение мира каждые 5 минут", "Auto-save world every 5 minutes", "Welt alle 5 Minuten automatisch speichern", "Automatyczny zapis świata co 5 minut", "Automatické ukládání světa každých 5 minut" });
             AddNewWord("TT_AUTOSAVE_CHECKBOX", new List<string> { "Автосохранение каждые 5 минут в подпапку autosave/ (10 ротирующихся слотов)", "Auto-save every 5 minutes into autosave/ subfolder (10 rotating slots)", "Auto-Speichern alle 5 Minuten in autosave/-Unterordner (10 rotierende Slots)", "Automatyczne zapisywanie co 5 minut do podfolderu autosave/ (10 rotujących slotów)", "Automatické ukládání každých 5 minut do podsložky autosave/ (10 rotujících slotů)" });
 
+            AddNewWord("STATUS_WORLD", new List<string> { "Мир:", "World:", "Welt:", "Świat:", "Svět:" });
+            AddNewWord("STATUS_TRIS", new List<string> { "Поли:", "Tris:", "Tris:", "Tris:", "Tris:" });
+            AddNewWord("STATUS_RAM", new List<string> { "ОЗУ:", "RAM:", "RAM:", "RAM:", "RAM:" });
+
             AddNewWord("UNION_VOB_UPSIDE_DOWN", new List<string> { "Воб успешно перевернут", "Vob has been flipped", "VOB wurde erfolgreich gedreht", "", "" });
             AddNewWord("KEYS_SET_UPSIDE_DOWN", new List<string> { "Перевернуть воб", "Flip vob upside down", "VOB drehen", "", "" });
             AddNewWord("WIN_CAMERA_AUTO_RENAME", new List<string> { "Авто-переименовывание ключей с пустыми именам", "Auto rename keys which have empty names", "VOB drehen", "Tasten mit leerem Namen automatisch umbenennen", "" });

--- a/SpacerNET_Interface/Common/Theme.cs
+++ b/SpacerNET_Interface/Common/Theme.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Drawing;
+
+namespace SpacerUnion.Common
+{
+    public static class Theme
+    {
+        public static Color BgPanel   { get { return SystemColors.Control; } }
+        public static Color BgInput   { get { return SystemColors.Window; } }
+        public static Color FgPrimary { get { return SystemColors.ControlText; } }
+        public static Color FgMuted   { get { return SystemColors.GrayText; } }
+        public static Color Accent    { get { return Color.FromArgb(0, 120, 215); } }
+        public static Color Warning   { get { return Color.FromArgb(220, 130, 0); } }
+        public static Color Error     { get { return Color.FromArgb(200, 40, 40); } }
+
+        public static int PaddingS { get { return 4; } }
+        public static int PaddingM { get { return 8; } }
+        public static int PaddingL { get { return 16; } }
+
+        public static bool IsDark { get; set; }
+
+        public static event Action ThemeChanged;
+
+        public static void RaiseChanged()
+        {
+            var handler = ThemeChanged;
+            if (handler != null) handler();
+        }
+    }
+}

--- a/SpacerNET_Interface/Common/ToolTipManager.cs
+++ b/SpacerNET_Interface/Common/ToolTipManager.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace SpacerUnion.Common
+{
+    public static class ToolTipManager
+    {
+        private static readonly ToolTip _tip = new ToolTip
+        {
+            ShowAlways   = true,
+            AutoPopDelay = 10000,
+            InitialDelay = 500,
+            ReshowDelay  = 100
+        };
+
+        private static readonly Dictionary<Control, string> _bindings = new Dictionary<Control, string>();
+
+        public static void Set(Control c, string locKey)
+        {
+            if (c == null || string.IsNullOrEmpty(locKey)) return;
+            _bindings[c] = locKey;
+            _tip.SetToolTip(c, Localizator.Get(locKey));
+        }
+
+        public static void Clear(Control c)
+        {
+            if (c == null) return;
+            _bindings.Remove(c);
+            _tip.SetToolTip(c, string.Empty);
+        }
+
+        public static void RetranslateAll()
+        {
+            foreach (var kv in _bindings)
+            {
+                _tip.SetToolTip(kv.Key, Localizator.Get(kv.Value));
+            }
+        }
+    }
+}

--- a/SpacerNET_Interface/SpacerNET_Interface.csproj
+++ b/SpacerNET_Interface/SpacerNET_Interface.csproj
@@ -89,6 +89,8 @@
     <Compile Include="Common\Localizator.cs" />
     <Compile Include="Common\LocalizedStrings.cs" />
     <Compile Include="Common\Macros.cs" />
+    <Compile Include="Common\Theme.cs" />
+    <Compile Include="Common\ToolTipManager.cs" />
     <Compile Include="Common\PFX_Editor\PFXEditorWin_Utils.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/SpacerNET_Interface/Windows/MainForm.Designer.cs
+++ b/SpacerNET_Interface/Windows/MainForm.Designer.cs
@@ -130,7 +130,12 @@
             this.stopRainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.startRainsmoothlyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.startRainfullyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.statusStripBottom = new System.Windows.Forms.StatusStrip();
+            this.lblStatusWorld = new System.Windows.Forms.ToolStripStatusLabel();
+            this.lblStatusTris = new System.Windows.Forms.ToolStripStatusLabel();
+            this.lblStatusRam = new System.Windows.Forms.ToolStripStatusLabel();
             this.menuStripTopMain.SuspendLayout();
+            this.statusStripBottom.SuspendLayout();
             this.panelMain.SuspendLayout();
             this.toolStripTop.SuspendLayout();
             this.SuspendLayout();
@@ -1039,14 +1044,45 @@
             this.startRainfullyToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
             this.startRainfullyToolStripMenuItem.Text = "Start rain (fully)";
             this.startRainfullyToolStripMenuItem.Click += new System.EventHandler(this.startRainfullyToolStripMenuItem_Click);
-            // 
+            //
+            // statusStripBottom
+            //
+            this.statusStripBottom.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lblStatusWorld,
+            this.lblStatusTris,
+            this.lblStatusRam});
+            this.statusStripBottom.Location = new System.Drawing.Point(0, 561);
+            this.statusStripBottom.Name = "statusStripBottom";
+            this.statusStripBottom.SizingGrip = false;
+            this.statusStripBottom.Size = new System.Drawing.Size(1201, 22);
+            this.statusStripBottom.TabIndex = 4;
+            //
+            // lblStatusWorld
+            //
+            this.lblStatusWorld.Name = "lblStatusWorld";
+            this.lblStatusWorld.Size = new System.Drawing.Size(60, 17);
+            this.lblStatusWorld.Text = "World: —";
+            //
+            // lblStatusTris
+            //
+            this.lblStatusTris.Name = "lblStatusTris";
+            this.lblStatusTris.Size = new System.Drawing.Size(50, 17);
+            this.lblStatusTris.Text = "Tris: 0";
+            //
+            // lblStatusRam
+            //
+            this.lblStatusRam.Name = "lblStatusRam";
+            this.lblStatusRam.Size = new System.Drawing.Size(60, 17);
+            this.lblStatusRam.Text = "RAM: 0 MB";
+            //
             // MainForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Black;
             this.ClientSize = new System.Drawing.Size(1201, 583);
             this.Controls.Add(this.panelMain);
+            this.Controls.Add(this.statusStripBottom);
             this.Controls.Add(this.menuStripTopMain);
             this.DoubleBuffered = true;
             this.ForeColor = System.Drawing.Color.Transparent;
@@ -1064,6 +1100,8 @@
             this.panelMain.PerformLayout();
             this.toolStripTop.ResumeLayout(false);
             this.toolStripTop.PerformLayout();
+            this.statusStripBottom.ResumeLayout(false);
+            this.statusStripBottom.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1171,5 +1209,9 @@
         private System.Windows.Forms.ToolStripMenuItem startRainsmoothlyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem startRainfullyToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem rainToolStripMenuItem;
+        private System.Windows.Forms.StatusStrip statusStripBottom;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatusWorld;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatusTris;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatusRam;
     }
 }

--- a/SpacerNET_Interface/Windows/MainForm.cs
+++ b/SpacerNET_Interface/Windows/MainForm.cs
@@ -32,6 +32,8 @@ namespace SpacerUnion
         public Font mainUIFont = null;
         public float scaleIconsSize = 1.0f;
 
+        private System.Windows.Forms.Timer timerStatusBar;
+
         public enum ToggleMenuType
         {
             ToggleVobs = 0,
@@ -49,6 +51,25 @@ namespace SpacerUnion
 
 
             UpdateSpacerCaption("");
+
+            timerStatusBar = new System.Windows.Forms.Timer { Interval = 1000 };
+            timerStatusBar.Tick += TimerStatusBar_Tick;
+            timerStatusBar.Start();
+        }
+
+        private void TimerStatusBar_Tick(object sender, EventArgs e)
+        {
+            string world = string.IsNullOrEmpty(currentWorldName) ? "—" : currentWorldName;
+            int polys = 0;
+            if (!string.IsNullOrEmpty(currentWorldName))
+            {
+                polys = Imports.Extern_GetPolysCount();
+            }
+            long ramMb = Process.GetCurrentProcess().WorkingSet64 / (1024L * 1024L);
+
+            lblStatusWorld.Text = Localizator.Get("STATUS_WORLD") + " " + world;
+            lblStatusTris.Text = Localizator.Get("STATUS_TRIS") + " " + polys.ToString("N0");
+            lblStatusRam.Text = Localizator.Get("STATUS_RAM") + " " + ramMb + " MB";
         }
 
 

--- a/SpacerNET_Interface/Windows/MiscSettingsWin.cs
+++ b/SpacerNET_Interface/Windows/MiscSettingsWin.cs
@@ -40,7 +40,7 @@ namespace SpacerUnion.Windows
             checkBoxNoWorkCheck.Text = Localizator.Get("MISC_SETTINGS_NO_WORK_CHECK");
             checkBoxAutoSave.Text = Localizator.Get("checkBoxAutoSave");
 
-
+            ToolTipManager.Set(checkBoxAutoSave, "TT_AUTOSAVE_CHECKBOX");
 
             btnMiscSetApply.Text = Localizator.Get("BTN_APPLY");
         }


### PR DESCRIPTION
## Summary

Adds a `StatusStrip` docked at the bottom of `MainForm` with three labels that refresh once per second:

- **World** — current ZEN filename, or `—` when no world is loaded
- **Tris** — polygon count via `Extern_GetPolysCount` (only queried while a world is loaded, so no engine call when idle)
- **RAM** — process working set via `Process.GetCurrentProcess()` — pure C#, no engine round-trip

Three new `STATUS_*` loc keys: `STATUS_WORLD`, `STATUS_TRIS`, `STATUS_RAM`. They are short prefixes only (\"World:\", \"Tris:\", \"RAM:\"), so no risky translation work — I filled in RU/EN/DE/PL/CZ.

## What was considered but left out

- **Camera coordinates** and **FPS**: these would need new `Extern_*` exports on the C++ side. I left them out to keep this PR self-contained on the C# side. Happy to do a small follow-up SpacerNET_Union patch + a follow-up here once that lands.
- **View-menu toggle** to hide the status bar. Skipped to keep the PR small. The bar is 22 px tall and only shows three short labels, so it should not interfere with anything. If it turns out to bother anyone, a toggle is two lines + a setting.

## Depends on

#18 — branched off the foundation PR for clean stacking, but the actual code in this PR doesn't reference `Theme` or `ToolTipManager`. Once #18 is merged, this rebases cleanly to master.

## Test plan

- [ ] Open Spacer with no world → status bar shows \"World: —\", \"Tris: 0\", \"RAM: <some MB>\"; RAM updates every second
- [ ] Load a ZEN → World label switches to filename, Tris updates to actual poly count
- [ ] Switch language → all three label prefixes follow without restart
- [ ] No layout regressions: render area, top toolbar, menu bar all unaffected