### PR TITLE
Add optional dark mode

### DIFF
--- a/SpacerNET_Interface/Common/DarkToolStripRenderer.cs
+++ b/SpacerNET_Interface/Common/DarkToolStripRenderer.cs
@@ -1,0 +1,53 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SpacerUnion.Common
+{
+    public class DarkToolStripRenderer : ToolStripProfessionalRenderer
+    {
+        public DarkToolStripRenderer() : base(new DarkColors()) { }
+
+        protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
+        {
+            e.TextColor = Theme.FgPrimary;
+            base.OnRenderItemText(e);
+        }
+
+        protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
+        {
+            e.ArrowColor = Theme.FgPrimary;
+            base.OnRenderArrow(e);
+        }
+
+        private class DarkColors : ProfessionalColorTable
+        {
+            public override Color MenuItemSelected               { get { return Theme.MenuHigh; } }
+            public override Color MenuItemBorder                 { get { return Theme.Border; } }
+            public override Color MenuItemSelectedGradientBegin  { get { return Theme.MenuHigh; } }
+            public override Color MenuItemSelectedGradientEnd    { get { return Theme.MenuHigh; } }
+            public override Color MenuItemPressedGradientBegin   { get { return Theme.BgPanel; } }
+            public override Color MenuItemPressedGradientEnd     { get { return Theme.BgPanel; } }
+            public override Color MenuStripGradientBegin         { get { return Theme.BgPanel; } }
+            public override Color MenuStripGradientEnd           { get { return Theme.BgPanel; } }
+            public override Color MenuBorder                     { get { return Theme.Border; } }
+            public override Color ToolStripBorder                { get { return Theme.Border; } }
+            public override Color ToolStripGradientBegin         { get { return Theme.BgPanel; } }
+            public override Color ToolStripGradientEnd           { get { return Theme.BgPanel; } }
+            public override Color ToolStripGradientMiddle        { get { return Theme.BgPanel; } }
+            public override Color ToolStripDropDownBackground    { get { return Theme.BgPanel; } }
+            public override Color ImageMarginGradientBegin       { get { return Theme.BgPanel; } }
+            public override Color ImageMarginGradientEnd         { get { return Theme.BgPanel; } }
+            public override Color ImageMarginGradientMiddle      { get { return Theme.BgPanel; } }
+            public override Color SeparatorDark                  { get { return Theme.Border; } }
+            public override Color SeparatorLight                 { get { return Theme.Border; } }
+            public override Color StatusStripGradientBegin       { get { return Theme.BgPanel; } }
+            public override Color StatusStripGradientEnd         { get { return Theme.BgPanel; } }
+            public override Color ButtonSelectedHighlight        { get { return Theme.MenuHigh; } }
+            public override Color ButtonSelectedHighlightBorder  { get { return Theme.Border; } }
+            public override Color ButtonCheckedHighlight         { get { return Theme.MenuHigh; } }
+            public override Color CheckBackground                { get { return Theme.MenuHigh; } }
+            public override Color CheckSelectedBackground        { get { return Theme.MenuHigh; } }
+            public override Color CheckPressedBackground         { get { return Theme.MenuHigh; } }
+        }
+    }
+}

--- a/SpacerNET_Interface/Common/Localizator.cs
+++ b/SpacerNET_Interface/Common/Localizator.cs
@@ -131,6 +131,8 @@ namespace SpacerUnion.Common
             SpacerNET.vobCatForm.UpdateLang();
             SpacerNET.vobCatForm.propsForm.UpdateLang();
             SpacerNET.uvForm.UpdateLang();
+
+            ToolTipManager.RetranslateAll();
         }
 
         [DllExport]

--- a/SpacerNET_Interface/Common/LocalizedStrings.cs
+++ b/SpacerNET_Interface/Common/LocalizedStrings.cs
@@ -962,6 +962,7 @@ namespace SpacerUnion.Common
             AddNewWord("WIN_GRASS_SET_ON_VOB", new List<string> { "Ставить объекты на вобы", "Set objects on vobs", "Objekte auf VOBs platzieren", "", "" });
             AddNewWord("MISC_SETTINGS_NO_WORK_CHECK", new List<string> { "Не проверять путь загружаемого ZEN (игнорировать папку _WORK)", "Don't check path while loading ZEN (ignore _WORK folder)", "Beim Laden von ZEN den Pfad nicht prüfen (Ordner _WORK ignorieren)", "", "" });
             AddNewWord("checkBoxAutoSave", new List<string> { "Автосохранение мира каждые 5 минут", "Auto-save world every 5 minutes", "Welt alle 5 Minuten automatisch speichern", "Automatyczny zapis świata co 5 minut", "Automatické ukládání světa každých 5 minut" });
+            AddNewWord("TT_AUTOSAVE_CHECKBOX", new List<string> { "Автосохранение каждые 5 минут в подпапку autosave/ (10 ротирующихся слотов)", "Auto-save every 5 minutes into autosave/ subfolder (10 rotating slots)", "Auto-Speichern alle 5 Minuten in autosave/-Unterordner (10 rotierende Slots)", "Automatyczne zapisywanie co 5 minut do podfolderu autosave/ (10 rotujących slotów)", "Automatické ukládání každých 5 minut do podsložky autosave/ (10 rotujících slotů)" });
 
             AddNewWord("UNION_VOB_UPSIDE_DOWN", new List<string> { "Воб успешно перевернут", "Vob has been flipped", "VOB wurde erfolgreich gedreht", "", "" });
             AddNewWord("KEYS_SET_UPSIDE_DOWN", new List<string> { "Перевернуть воб", "Flip vob upside down", "VOB drehen", "", "" });

--- a/SpacerNET_Interface/Common/LocalizedStrings.cs
+++ b/SpacerNET_Interface/Common/LocalizedStrings.cs
@@ -964,6 +964,9 @@ namespace SpacerUnion.Common
             AddNewWord("checkBoxAutoSave", new List<string> { "Автосохранение мира каждые 5 минут", "Auto-save world every 5 minutes", "Welt alle 5 Minuten automatisch speichern", "Automatyczny zapis świata co 5 minut", "Automatické ukládání světa každých 5 minut" });
             AddNewWord("TT_AUTOSAVE_CHECKBOX", new List<string> { "Автосохранение каждые 5 минут в подпапку autosave/ (10 ротирующихся слотов)", "Auto-save every 5 minutes into autosave/ subfolder (10 rotating slots)", "Auto-Speichern alle 5 Minuten in autosave/-Unterordner (10 rotierende Slots)", "Automatyczne zapisywanie co 5 minut do podfolderu autosave/ (10 rotujących slotów)", "Automatické ukládání každých 5 minut do podsložky autosave/ (10 rotujících slotů)" });
 
+            AddNewWord("checkBoxDarkMode", new List<string> { "Тёмная тема", "Dark mode", "Dunkles Design", "Tryb ciemny", "Tmavý režim" });
+            AddNewWord("TT_MISC_DARK_MODE", new List<string> { "Включает тёмное оформление для всех окон редактора. Применяется без перезапуска", "Switches all editor windows to a dark color scheme. Applied without restart", "Schaltet alle Editor-Fenster auf ein dunkles Farbschema. Wird ohne Neustart übernommen", "", "" });
+
             AddNewWord("UNION_VOB_UPSIDE_DOWN", new List<string> { "Воб успешно перевернут", "Vob has been flipped", "VOB wurde erfolgreich gedreht", "", "" });
             AddNewWord("KEYS_SET_UPSIDE_DOWN", new List<string> { "Перевернуть воб", "Flip vob upside down", "VOB drehen", "", "" });
             AddNewWord("WIN_CAMERA_AUTO_RENAME", new List<string> { "Авто-переименовывание ключей с пустыми именам", "Auto rename keys which have empty names", "VOB drehen", "Tasten mit leerem Namen automatisch umbenennen", "" });

--- a/SpacerNET_Interface/Common/SpacerNET.cs
+++ b/SpacerNET_Interface/Common/SpacerNET.cs
@@ -69,6 +69,13 @@ namespace SpacerUnion
 
             Localizator.Init();
             Localizator.SetLanguage((LangEnum)Properties.Settings.Default.Language);
+
+            Theme.IsDark = Properties.Settings.Default.DarkMode;
+            Theme.ThemeChanged += () =>
+            {
+                if (windowsList != null) ThemeApplier.ApplyAll(windowsList);
+                if (form != null) ThemeApplier.Apply(form);
+            };
            
             
             
@@ -127,6 +134,12 @@ namespace SpacerUnion
             form.menuStripTopMain.Enabled = false;
 
             Localizator.UpdateInterface();
+
+            if (Theme.IsDark)
+            {
+                ThemeApplier.Apply(form);
+                ThemeApplier.ApplyAll(windowsList);
+            }
 
             form.Show();
 

--- a/SpacerNET_Interface/Common/Theme.cs
+++ b/SpacerNET_Interface/Common/Theme.cs
@@ -5,11 +5,32 @@ namespace SpacerUnion.Common
 {
     public static class Theme
     {
-        public static Color BgPanel   { get { return SystemColors.Control; } }
-        public static Color BgInput   { get { return SystemColors.Window; } }
-        public static Color FgPrimary { get { return SystemColors.ControlText; } }
-        public static Color FgMuted   { get { return SystemColors.GrayText; } }
-        public static Color Accent    { get { return Color.FromArgb(0, 120, 215); } }
+        // Light variants
+        private static readonly Color _lBgPanel  = SystemColors.Control;
+        private static readonly Color _lBgInput  = SystemColors.Window;
+        private static readonly Color _lFgPrim   = SystemColors.ControlText;
+        private static readonly Color _lFgMuted  = SystemColors.GrayText;
+        private static readonly Color _lAccent   = Color.FromArgb(0, 120, 215);
+        private static readonly Color _lBorder   = Color.FromArgb(160, 160, 160);
+        private static readonly Color _lMenuHigh = Color.FromArgb(204, 232, 255);
+
+        // Dark variants
+        private static readonly Color _dBgPanel  = Color.FromArgb(45, 45, 48);
+        private static readonly Color _dBgInput  = Color.FromArgb(30, 30, 30);
+        private static readonly Color _dFgPrim   = Color.FromArgb(241, 241, 241);
+        private static readonly Color _dFgMuted  = Color.FromArgb(153, 153, 153);
+        private static readonly Color _dAccent   = Color.FromArgb(0, 122, 204);
+        private static readonly Color _dBorder   = Color.FromArgb(67, 67, 70);
+        private static readonly Color _dMenuHigh = Color.FromArgb(62, 62, 64);
+
+        public static Color BgPanel   { get { return IsDark ? _dBgPanel  : _lBgPanel; } }
+        public static Color BgInput   { get { return IsDark ? _dBgInput  : _lBgInput; } }
+        public static Color FgPrimary { get { return IsDark ? _dFgPrim   : _lFgPrim; } }
+        public static Color FgMuted   { get { return IsDark ? _dFgMuted  : _lFgMuted; } }
+        public static Color Accent    { get { return IsDark ? _dAccent   : _lAccent; } }
+        public static Color Border    { get { return IsDark ? _dBorder   : _lBorder; } }
+        public static Color MenuHigh  { get { return IsDark ? _dMenuHigh : _lMenuHigh; } }
+
         public static Color Warning   { get { return Color.FromArgb(220, 130, 0); } }
         public static Color Error     { get { return Color.FromArgb(200, 40, 40); } }
 

--- a/SpacerNET_Interface/Common/Theme.cs
+++ b/SpacerNET_Interface/Common/Theme.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Drawing;
+
+namespace SpacerUnion.Common
+{
+    public static class Theme
+    {
+        public static Color BgPanel   { get { return SystemColors.Control; } }
+        public static Color BgInput   { get { return SystemColors.Window; } }
+        public static Color FgPrimary { get { return SystemColors.ControlText; } }
+        public static Color FgMuted   { get { return SystemColors.GrayText; } }
+        public static Color Accent    { get { return Color.FromArgb(0, 120, 215); } }
+        public static Color Warning   { get { return Color.FromArgb(220, 130, 0); } }
+        public static Color Error     { get { return Color.FromArgb(200, 40, 40); } }
+
+        public static int PaddingS { get { return 4; } }
+        public static int PaddingM { get { return 8; } }
+        public static int PaddingL { get { return 16; } }
+
+        public static bool IsDark { get; set; }
+
+        public static event Action ThemeChanged;
+
+        public static void RaiseChanged()
+        {
+            var handler = ThemeChanged;
+            if (handler != null) handler();
+        }
+    }
+}

--- a/SpacerNET_Interface/Common/ThemeApplier.cs
+++ b/SpacerNET_Interface/Common/ThemeApplier.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace SpacerUnion.Common
+{
+    public static class ThemeApplier
+    {
+        public static void Apply(Form form)
+        {
+            if (form == null) return;
+            ApplyToControl(form);
+            ApplyRecursive(form);
+            form.Invalidate(true);
+        }
+
+        public static void ApplyAll(IEnumerable<Form> forms)
+        {
+            if (forms == null) return;
+            foreach (var f in forms)
+            {
+                if (f != null) Apply(f);
+            }
+        }
+
+        private static void ApplyRecursive(Control parent)
+        {
+            foreach (Control c in parent.Controls)
+            {
+                ApplyToControl(c);
+                if (c.HasChildren) ApplyRecursive(c);
+            }
+        }
+
+        private static void ApplyToControl(Control c)
+        {
+            if (c == null) return;
+
+            if (c is TextBox || c is RichTextBox || c is ComboBox || c is ListBox || c is TreeView || c is DataGridView || c is NumericUpDown)
+            {
+                c.BackColor = Theme.BgInput;
+                c.ForeColor = Theme.FgPrimary;
+                return;
+            }
+
+            if (c is Button)
+            {
+                var b = (Button)c;
+                b.BackColor = Theme.BgPanel;
+                b.ForeColor = Theme.FgPrimary;
+                b.UseVisualStyleBackColor = !Theme.IsDark;
+                if (Theme.IsDark)
+                {
+                    b.FlatStyle = FlatStyle.Flat;
+                    b.FlatAppearance.BorderColor = Theme.Border;
+                }
+                else
+                {
+                    b.FlatStyle = FlatStyle.Standard;
+                }
+                return;
+            }
+
+            if (c is MenuStrip || c is ToolStrip || c is StatusStrip)
+            {
+                var ts = (ToolStrip)c;
+                ts.BackColor = Theme.BgPanel;
+                ts.ForeColor = Theme.FgPrimary;
+                ts.Renderer = Theme.IsDark
+                    ? (ToolStripRenderer)new DarkToolStripRenderer()
+                    : new ToolStripProfessionalRenderer();
+                return;
+            }
+
+            // Forms, panels, group boxes, labels, checkboxes, radios — generic
+            c.BackColor = Theme.BgPanel;
+            c.ForeColor = Theme.FgPrimary;
+        }
+    }
+}

--- a/SpacerNET_Interface/Common/ToolTipManager.cs
+++ b/SpacerNET_Interface/Common/ToolTipManager.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace SpacerUnion.Common
+{
+    public static class ToolTipManager
+    {
+        private static readonly ToolTip _tip = new ToolTip
+        {
+            ShowAlways   = true,
+            AutoPopDelay = 10000,
+            InitialDelay = 500,
+            ReshowDelay  = 100
+        };
+
+        private static readonly Dictionary<Control, string> _bindings = new Dictionary<Control, string>();
+
+        public static void Set(Control c, string locKey)
+        {
+            if (c == null || string.IsNullOrEmpty(locKey)) return;
+            _bindings[c] = locKey;
+            _tip.SetToolTip(c, Localizator.Get(locKey));
+        }
+
+        public static void Clear(Control c)
+        {
+            if (c == null) return;
+            _bindings.Remove(c);
+            _tip.SetToolTip(c, string.Empty);
+        }
+
+        public static void RetranslateAll()
+        {
+            foreach (var kv in _bindings)
+            {
+                _tip.SetToolTip(kv.Key, Localizator.Get(kv.Value));
+            }
+        }
+    }
+}

--- a/SpacerNET_Interface/Properties/Settings.Designer.cs
+++ b/SpacerNET_Interface/Properties/Settings.Designer.cs
@@ -286,7 +286,19 @@ namespace SpacerUnion.Properties {
                 this["MainWindowMaxState"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DarkMode {
+            get {
+                return ((bool)(this["DarkMode"]));
+            }
+            set {
+                this["DarkMode"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("405, 492")]

--- a/SpacerNET_Interface/Properties/Settings.settings
+++ b/SpacerNET_Interface/Properties/Settings.settings
@@ -68,6 +68,9 @@
     <Setting Name="MainWindowMaxState" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="DarkMode" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="TreeWinSize" Type="System.Drawing.Size" Scope="User">
       <Value Profile="(Default)">405, 492</Value>
     </Setting>

--- a/SpacerNET_Interface/SpacerNET_Interface.csproj
+++ b/SpacerNET_Interface/SpacerNET_Interface.csproj
@@ -89,6 +89,8 @@
     <Compile Include="Common\Localizator.cs" />
     <Compile Include="Common\LocalizedStrings.cs" />
     <Compile Include="Common\Macros.cs" />
+    <Compile Include="Common\Theme.cs" />
+    <Compile Include="Common\ToolTipManager.cs" />
     <Compile Include="Common\PFX_Editor\PFXEditorWin_Utils.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/SpacerNET_Interface/SpacerNET_Interface.csproj
+++ b/SpacerNET_Interface/SpacerNET_Interface.csproj
@@ -90,6 +90,8 @@
     <Compile Include="Common\LocalizedStrings.cs" />
     <Compile Include="Common\Macros.cs" />
     <Compile Include="Common\Theme.cs" />
+    <Compile Include="Common\ThemeApplier.cs" />
+    <Compile Include="Common\DarkToolStripRenderer.cs" />
     <Compile Include="Common\ToolTipManager.cs" />
     <Compile Include="Common\PFX_Editor\PFXEditorWin_Utils.cs">
       <SubType>Form</SubType>

--- a/SpacerNET_Interface/Windows/MiscSettingsWin.Designer.cs
+++ b/SpacerNET_Interface/Windows/MiscSettingsWin.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.checkBoxSetDatePrefix = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.checkBoxDarkMode = new System.Windows.Forms.CheckBox();
             this.checkBoxAutoSave = new System.Windows.Forms.CheckBox();
             this.checkBoxNoWorkCheck = new System.Windows.Forms.CheckBox();
             this.checkBoxSkipPolysCut = new System.Windows.Forms.CheckBox();
@@ -63,6 +64,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.checkBoxDarkMode);
             this.groupBox1.Controls.Add(this.checkBoxAutoSave);
             this.groupBox1.Controls.Add(this.checkBoxNoWorkCheck);
             this.groupBox1.Controls.Add(this.checkBoxSkipPolysCut);
@@ -83,9 +85,19 @@
             this.groupBox1.Controls.Add(this.checkBoxSetDatePrefix);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(624, 474);
+            this.groupBox1.Size = new System.Drawing.Size(624, 500);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
+            //
+            // checkBoxDarkMode
+            //
+            this.checkBoxDarkMode.AutoSize = true;
+            this.checkBoxDarkMode.Location = new System.Drawing.Point(13, 470);
+            this.checkBoxDarkMode.Name = "checkBoxDarkMode";
+            this.checkBoxDarkMode.Size = new System.Drawing.Size(150, 17);
+            this.checkBoxDarkMode.TabIndex = 20;
+            this.checkBoxDarkMode.Text = "Dark mode";
+            this.checkBoxDarkMode.UseVisualStyleBackColor = true;
             //
             // checkBoxAutoSave
             //
@@ -283,7 +295,7 @@
             // 
             // btnMiscSetApply
             // 
-            this.btnMiscSetApply.Location = new System.Drawing.Point(275, 492);
+            this.btnMiscSetApply.Location = new System.Drawing.Point(275, 520);
             this.btnMiscSetApply.Name = "btnMiscSetApply";
             this.btnMiscSetApply.Size = new System.Drawing.Size(115, 23);
             this.btnMiscSetApply.TabIndex = 11;
@@ -295,7 +307,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(648, 527);
+            this.ClientSize = new System.Drawing.Size(648, 555);
             this.Controls.Add(this.btnMiscSetApply);
             this.Controls.Add(this.groupBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -335,5 +347,6 @@
         public System.Windows.Forms.CheckBox checkBoxSkipPolysCut;
         public System.Windows.Forms.CheckBox checkBoxNoWorkCheck;
         public System.Windows.Forms.CheckBox checkBoxAutoSave;
+        public System.Windows.Forms.CheckBox checkBoxDarkMode;
     }
 }

--- a/SpacerNET_Interface/Windows/MiscSettingsWin.cs
+++ b/SpacerNET_Interface/Windows/MiscSettingsWin.cs
@@ -40,7 +40,7 @@ namespace SpacerUnion.Windows
             checkBoxNoWorkCheck.Text = Localizator.Get("MISC_SETTINGS_NO_WORK_CHECK");
             checkBoxAutoSave.Text = Localizator.Get("checkBoxAutoSave");
 
-
+            ToolTipManager.Set(checkBoxAutoSave, "TT_AUTOSAVE_CHECKBOX");
 
             btnMiscSetApply.Text = Localizator.Get("BTN_APPLY");
         }

--- a/SpacerNET_Interface/Windows/MiscSettingsWin.cs
+++ b/SpacerNET_Interface/Windows/MiscSettingsWin.cs
@@ -39,8 +39,10 @@ namespace SpacerUnion.Windows
             checkBoxSkipPolysCut.Text = Localizator.Get("checkBoxSkipPolysCut");
             checkBoxNoWorkCheck.Text = Localizator.Get("MISC_SETTINGS_NO_WORK_CHECK");
             checkBoxAutoSave.Text = Localizator.Get("checkBoxAutoSave");
+            checkBoxDarkMode.Text = Localizator.Get("checkBoxDarkMode");
 
             ToolTipManager.Set(checkBoxAutoSave, "TT_AUTOSAVE_CHECKBOX");
+            ToolTipManager.Set(checkBoxDarkMode, "TT_MISC_DARK_MODE");
 
             btnMiscSetApply.Text = Localizator.Get("BTN_APPLY");
         }
@@ -111,6 +113,7 @@ namespace SpacerUnion.Windows
             Imports.Stack_PushString("checkBoxAutoSave");
             SpacerNET.miscSetWin.checkBoxAutoSave.Checked = Convert.ToBoolean(Imports.Extern_GetSetting());
 
+            SpacerNET.miscSetWin.checkBoxDarkMode.Checked = Properties.Settings.Default.DarkMode;
         }
 
         public void OnApplySettings()
@@ -168,6 +171,14 @@ namespace SpacerUnion.Windows
 
             Imports.Stack_PushString("checkBoxAutoSave");
             Imports.Extern_SetSetting(Convert.ToInt32(checkBoxAutoSave.Checked));
+
+            if (Properties.Settings.Default.DarkMode != checkBoxDarkMode.Checked)
+            {
+                Properties.Settings.Default.DarkMode = checkBoxDarkMode.Checked;
+                Properties.Settings.Default.Save();
+                Theme.IsDark = checkBoxDarkMode.Checked;
+                Theme.RaiseChanged();
+            }
         }
 
         private void MiscSettingsWin_FormClosing(object sender, FormClosingEventArgs e)

--- a/SpacerNET_Interface/app.config
+++ b/SpacerNET_Interface/app.config
@@ -73,6 +73,9 @@
             <setting name="MainWindowMaxState" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="DarkMode" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="TreeWinSize" serializeAs="String">
                 <value>405, 492</value>
             </setting>


### PR DESCRIPTION
## Summary

Adds an opt-in dark color scheme for all editor windows. **Off by default.** Toggle is a checkbox in Misc Settings, applies live without restart, persists via `Properties.Settings`.

### Three new files

- **`Common/Theme.cs`** — extended with parallel Light + Dark color sets behind the existing `IsDark` switch. Properties auto-pick the right set; no caller code changes.
- **`Common/ThemeApplier.cs`** — recursive form walker that adapts each control:
  - Input controls (`TextBox`, `RichTextBox`, `ComboBox`, `ListBox`, `TreeView`, `DataGridView`, `NumericUpDown`) get `BgInput` / `FgPrimary`
  - Buttons get `FlatStyle.Flat` + bordered look in dark (otherwise stay native)
  - `MenuStrip` / `ToolStrip` / `StatusStrip` get `DarkToolStripRenderer` in dark, default professional renderer in light
  - Everything else (forms, panels, group boxes, labels, checkboxes) gets `BgPanel` / `FgPrimary`
- **`Common/DarkToolStripRenderer.cs`** — `ToolStripProfessionalRenderer` subclass with a `DarkColors : ProfessionalColorTable` so menus, dropdowns, separators and status bars paint cleanly in dark instead of falling back to the default light gradients.

### Wiring

- `SpacerNET.UnionInitialize`:
  - Reads `Properties.Settings.Default.DarkMode` into `Theme.IsDark`
  - Subscribes to `Theme.ThemeChanged` so toggling re-applies across the whole window list
  - Applies once on startup if dark is active
- `MiscSettingsWin`:
  - New `checkBoxDarkMode` (TabIndex 20, immediately below the Auto-save checkbox added in the previous PR)
  - `OnApplySettings` persists to `Properties.Settings.Default.DarkMode` and raises `ThemeChanged` for a live switch
- `app.config` and `Settings.settings` updated with the new bool entry, default `False`.

### Translations

- `checkBoxDarkMode` label: all five languages (RU / EN / DE / PL / CZ).
- `TT_MISC_DARK_MODE` tooltip: RU / EN / DE filled, PL / CZ left empty (EN fallback). Native review welcome.

### What is intentionally **not** in this PR

- **Custom dark icon variants** for `ToolStrip`. Existing icons render on the dark background but some look a little muddy — easy follow-up.
- **Bespoke handling** for individual heavy controls (`DataGridView` cell colors, custom-painted `DBufPanel`). The walker treats them generically; might need polishing.

I marked this as an initial pass in the commit message — review feedback and polish are very welcome. The whole feature is one bool flip away from being unreachable, so risk to default users (who never enable it) is essentially zero.

## Depends on

#18 — uses the `Theme` and (indirectly) the `ToolTipManager` from that PR. Once #18 is merged this rebases cleanly to master.

## Test plan

- [ ] Default install → light theme as before, no visible changes
- [ ] Open Misc Settings → tick \"Dark mode\" → Apply → all 21 windows switch to dark live
- [ ] Untick \"Dark mode\" → all windows switch back to light
- [ ] Restart → dark/light state persists
- [ ] Switch language while dark → labels update, no flicker
- [ ] Hover over checkboxes → tooltips visible in both themes