### PR TITLE
fix(dark mode): readable disabled state + dark-skin DataGridView/ListView/ComboBox

### DIFF
--- a/SpacerNET_Interface/Common/Macros.cs
+++ b/SpacerNET_Interface/Common/Macros.cs
@@ -78,6 +78,7 @@ namespace SpacerUnion.Common
             objWin = win;
 
             formConf = new ConfirmForm(this);
+            ThemeApplier.RegisterDialog(formConf);
             pathFile = Path.GetFullPath(@"../_work/tools/macros_spacernet.txt");
 
             //ConsoleEx.WriteLineRed(pathFile);

--- a/SpacerNET_Interface/Common/SpacerNET.cs
+++ b/SpacerNET_Interface/Common/SpacerNET.cs
@@ -75,6 +75,7 @@ namespace SpacerUnion
             {
                 if (windowsList != null) ThemeApplier.ApplyAll(windowsList);
                 if (form != null) ThemeApplier.Apply(form);
+                ThemeApplier.ReapplyRegisteredDialogs();
             };
            
             

--- a/SpacerNET_Interface/Common/ThemeApplier.cs
+++ b/SpacerNET_Interface/Common/ThemeApplier.cs
@@ -11,6 +11,19 @@ namespace SpacerUnion.Common
         private static readonly HashSet<GroupBox> _gbHandlers = new HashSet<GroupBox>();
         private static readonly HashSet<TabControl> _tabHandlers = new HashSet<TabControl>();
         private static readonly HashSet<Form> _shownHooks = new HashSet<Form>();
+        private static readonly HashSet<Button> _btnPaintHooks = new HashSet<Button>();
+        private static readonly HashSet<CheckBox> _chkPaintHooks = new HashSet<CheckBox>();
+        private static readonly HashSet<RadioButton> _radioPaintHooks = new HashSet<RadioButton>();
+        private static readonly HashSet<ListView> _lvHandlers = new HashSet<ListView>();
+        private static readonly HashSet<ComboBox> _cbHandlers = new HashSet<ComboBox>();
+        private static readonly HashSet<Label> _lblPaintHooks = new HashSet<Label>();
+        private static readonly HashSet<TreeView> _tvHandlers = new HashSet<TreeView>();
+        private static readonly HashSet<ImageList> _ilDarkApplied = new HashSet<ImageList>();
+        private static readonly List<Form> _registeredDialogs = new List<Form>();
+
+        // Disabled-state in dark mode — system default is unreadable (grey-on-grey).
+        // 165/165/165 gives clear contrast against BgPanel (45/45/48) without looking enabled.
+        private static readonly Color _dDisabledFg = Color.FromArgb(165, 165, 165);
 
         [DllImport("dwmapi.dll", PreserveSig = true)]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
@@ -79,6 +92,24 @@ namespace SpacerUnion.Common
             }
         }
 
+        // Modal dialogs constructed by parent forms (e.g. ConfirmForm, VobCatalog Add/Edit) aren't in
+        // SpacerNET.windowsList, so the global ApplyAll pass skips them. Parents call RegisterDialog
+        // once at construction time; ReapplyRegisteredDialogs runs on theme switch.
+        public static void RegisterDialog(Form dialog)
+        {
+            if (dialog == null) return;
+            if (!_registeredDialogs.Contains(dialog)) _registeredDialogs.Add(dialog);
+            Apply(dialog);
+        }
+
+        public static void ReapplyRegisteredDialogs()
+        {
+            foreach (var d in _registeredDialogs)
+            {
+                if (d != null && !d.IsDisposed) Apply(d);
+            }
+        }
+
         public static void ApplyAll(IEnumerable<Form> forms)
         {
             if (forms == null) return;
@@ -133,34 +164,29 @@ namespace SpacerUnion.Common
 
             if (c is TreeView)
             {
-                var tv = (TreeView)c;
-                tv.BackColor = Theme.BgInput;
-                tv.ForeColor = Theme.FgPrimary;
-                tv.BorderStyle = Theme.IsDark ? BorderStyle.FixedSingle : BorderStyle.Fixed3D;
-                TryDarkenNative(tv);
+                ApplyTreeView((TreeView)c);
                 return;
             }
 
             if (c is ListView)
             {
-                var lv = (ListView)c;
-                lv.BackColor = Theme.BgInput;
-                lv.ForeColor = Theme.FgPrimary;
-                TryDarkenNative(lv);
+                ApplyListView((ListView)c);
                 return;
             }
 
             if (c is ComboBox)
             {
-                var cb = (ComboBox)c;
-                cb.BackColor = Theme.BgInput;
-                cb.ForeColor = Theme.FgPrimary;
-                cb.FlatStyle = Theme.IsDark ? FlatStyle.Flat : FlatStyle.Standard;
-                TryDarkenNative(cb);
+                ApplyComboBox((ComboBox)c);
                 return;
             }
 
-            if (c is DataGridView || c is NumericUpDown)
+            if (c is DataGridView)
+            {
+                ApplyDataGridView((DataGridView)c);
+                return;
+            }
+
+            if (c is NumericUpDown)
             {
                 c.BackColor = Theme.BgInput;
                 c.ForeColor = Theme.FgPrimary;
@@ -171,17 +197,53 @@ namespace SpacerUnion.Common
             if (c is Button)
             {
                 var b = (Button)c;
+                // UseVisualStyleBackColor MUST be cleared before setting BackColor — otherwise
+                // WinForms silently discards the BackColor in favor of the system visual style.
+                b.UseVisualStyleBackColor = !Theme.IsDark;
                 b.BackColor = Theme.BgPanel;
                 b.ForeColor = Theme.FgPrimary;
-                b.UseVisualStyleBackColor = !Theme.IsDark;
                 if (Theme.IsDark)
                 {
                     b.FlatStyle = FlatStyle.Flat;
                     b.FlatAppearance.BorderColor = Theme.Border;
+                    if (!_btnPaintHooks.Contains(b))
+                    {
+                        b.Paint += Button_PaintDisabledOverlay;
+                        b.EnabledChanged += Button_EnabledChanged;
+                        _btnPaintHooks.Add(b);
+                    }
                 }
                 else
                 {
                     b.FlatStyle = FlatStyle.Standard;
+                }
+                return;
+            }
+
+            if (c is CheckBox)
+            {
+                var cb = (CheckBox)c;
+                cb.BackColor = Theme.BgPanel;
+                cb.ForeColor = Theme.FgPrimary;
+                if (Theme.IsDark && !_chkPaintHooks.Contains(cb))
+                {
+                    cb.Paint += CheckBox_PaintDisabledOverlay;
+                    cb.EnabledChanged += CheckBox_EnabledChanged;
+                    _chkPaintHooks.Add(cb);
+                }
+                return;
+            }
+
+            if (c is RadioButton)
+            {
+                var rb = (RadioButton)c;
+                rb.BackColor = Theme.BgPanel;
+                rb.ForeColor = Theme.FgPrimary;
+                if (Theme.IsDark && !_radioPaintHooks.Contains(rb))
+                {
+                    rb.Paint += RadioButton_PaintDisabledOverlay;
+                    rb.EnabledChanged += RadioButton_EnabledChanged;
+                    _radioPaintHooks.Add(rb);
                 }
                 return;
             }
@@ -226,9 +288,403 @@ namespace SpacerUnion.Common
                 return;
             }
 
-            // Forms, panels, labels, checkboxes, radios — generic
+            if (c is TabPage)
+            {
+                // TabPage defaults to UseVisualStyleBackColor=true, which silently discards BackColor
+                // in favor of the system visual style. Disable it before setting BackColor so the
+                // dark panel fill actually takes effect.
+                var tp = (TabPage)c;
+                tp.UseVisualStyleBackColor = !Theme.IsDark;
+                tp.BackColor = Theme.BgPanel;
+                tp.ForeColor = Theme.FgPrimary;
+                return;
+            }
+
+            if (c is Label)
+            {
+                var lbl = (Label)c;
+                lbl.ForeColor = Theme.FgPrimary;
+                if (Theme.IsDark && !_lblPaintHooks.Contains(lbl))
+                {
+                    lbl.Paint += Label_PaintDisabledOverlay;
+                    lbl.EnabledChanged += Label_EnabledChanged;
+                    _lblPaintHooks.Add(lbl);
+                }
+                return;
+            }
+
+            // Forms, panels — generic
             c.BackColor = Theme.BgPanel;
             c.ForeColor = Theme.FgPrimary;
+        }
+
+        // ---- ComboBox (DropDownList variant ignores BackColor without OwnerDraw) ---
+
+        private static void ApplyComboBox(ComboBox cb)
+        {
+            cb.BackColor = Theme.BgInput;
+            cb.ForeColor = Theme.FgPrimary;
+            cb.FlatStyle = Theme.IsDark ? FlatStyle.Flat : FlatStyle.Standard;
+            if (Theme.IsDark)
+            {
+                if (cb.DrawMode == DrawMode.Normal)
+                    cb.DrawMode = DrawMode.OwnerDrawFixed;
+                if (!_cbHandlers.Contains(cb))
+                {
+                    cb.DrawItem += ComboBox_DrawItem;
+                    _cbHandlers.Add(cb);
+                }
+            }
+            TryDarkenCombo(cb);
+        }
+
+        private static void TryDarkenCombo(Control c)
+        {
+            if (!c.IsHandleCreated) return;
+            try { SetWindowTheme(c.Handle, Theme.IsDark ? "DarkMode_CFD" : null, null); }
+            catch { }
+        }
+
+        private static void ComboBox_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            if (!Theme.IsDark) { e.DrawBackground(); return; }
+            var cb = (ComboBox)sender;
+            bool selected = (e.State & DrawItemState.Selected) != 0;
+            Color bgColor = selected ? Theme.Accent : Theme.BgInput;
+            using (var bg = new SolidBrush(bgColor))
+                e.Graphics.FillRectangle(bg, e.Bounds);
+            string text = (e.Index >= 0 && e.Index < cb.Items.Count)
+                ? cb.GetItemText(cb.Items[e.Index])
+                : string.Empty;
+            var pad = new Rectangle(e.Bounds.X + 2, e.Bounds.Y, Math.Max(0, e.Bounds.Width - 4), e.Bounds.Height);
+            TextRenderer.DrawText(e.Graphics, text, e.Font, pad, Theme.FgPrimary,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding | TextFormatFlags.EndEllipsis);
+        }
+
+        // ---- DataGridView ----------------------------------------------------------
+
+        private static void ApplyDataGridView(DataGridView dgv)
+        {
+            if (Theme.IsDark)
+            {
+                dgv.BackgroundColor = Theme.BgInput;
+                dgv.GridColor = Theme.Border;
+                dgv.BorderStyle = BorderStyle.FixedSingle;
+                dgv.EnableHeadersVisualStyles = false;
+
+                dgv.DefaultCellStyle.BackColor = Theme.BgInput;
+                dgv.DefaultCellStyle.ForeColor = Theme.FgPrimary;
+                dgv.DefaultCellStyle.SelectionBackColor = Theme.Accent;
+                dgv.DefaultCellStyle.SelectionForeColor = Theme.FgPrimary;
+
+                dgv.ColumnHeadersDefaultCellStyle.BackColor = Theme.BgPanel;
+                dgv.ColumnHeadersDefaultCellStyle.ForeColor = Theme.FgPrimary;
+                dgv.ColumnHeadersDefaultCellStyle.SelectionBackColor = Theme.BgPanel;
+                dgv.ColumnHeadersDefaultCellStyle.SelectionForeColor = Theme.FgPrimary;
+
+                dgv.RowHeadersDefaultCellStyle.BackColor = Theme.BgPanel;
+                dgv.RowHeadersDefaultCellStyle.ForeColor = Theme.FgPrimary;
+                dgv.RowHeadersDefaultCellStyle.SelectionBackColor = Theme.BgPanel;
+                dgv.RowHeadersDefaultCellStyle.SelectionForeColor = Theme.FgPrimary;
+            }
+            else
+            {
+                dgv.BackgroundColor = SystemColors.ButtonHighlight;
+                dgv.EnableHeadersVisualStyles = true;
+            }
+        }
+
+        // ---- TreeView (selection-highlight readable in dark mode) ------------------
+
+        private static void ApplyTreeView(TreeView tv)
+        {
+            tv.BackColor = Theme.BgInput;
+            tv.ForeColor = Theme.FgPrimary;
+            tv.BorderStyle = Theme.IsDark ? BorderStyle.FixedSingle : BorderStyle.Fixed3D;
+            ApplyImageListToDark(tv.ImageList);
+            if (Theme.IsDark)
+            {
+                // OwnerDrawText: handler paints text area only; OS keeps drawing indent + ImageList icons.
+                // This means existing designer-time DrawNode handlers (e.g. classesTreeView_DrawNode) fire
+                // too — they paint with SystemBrushes.Highlight on (selected && unfocused), but our handler
+                // runs after them and overpaints with Theme.Accent. Harmless.
+                tv.DrawMode = TreeViewDrawMode.OwnerDrawText;
+                if (!_tvHandlers.Contains(tv))
+                {
+                    tv.DrawNode += TreeView_DrawNode;
+                    _tvHandlers.Add(tv);
+                }
+            }
+            else
+            {
+                // Light mode: OS handles everything. Designer handlers become dormant at Normal.
+                tv.DrawMode = TreeViewDrawMode.Normal;
+            }
+            TryDarkenNative(tv);
+        }
+
+        // ImageList icons (especially the property-tree's imgClass16x16.png / selWP.png / folder.png)
+        // were embedded in the resx as 8bit/24bit bitmaps with a literal white backdrop. The designer
+        // set TransparentColor=Transparent, which means "no transparency" for these formats. Result:
+        // a white square framed each icon in dark mode.
+        //
+        // Critical: ImageList.TransparentColor only affects images added AFTER the setter is called.
+        // Existing entries keep their original transparency. Workaround: snapshot images, clear the
+        // list, set TransparentColor=White, then re-add — the white backdrop becomes transparent.
+        // Idempotent via _ilDarkApplied.
+        private static void ApplyImageListToDark(ImageList il)
+        {
+            if (il == null) return;
+            if (Theme.IsDark && !_ilDarkApplied.Contains(il))
+            {
+                try
+                {
+                    int count = il.Images.Count;
+                    if (count == 0)
+                    {
+                        il.TransparentColor = Color.White;
+                        _ilDarkApplied.Add(il);
+                        return;
+                    }
+                    var images = new Bitmap[count];
+                    var keys = new string[count];
+                    for (int i = 0; i < count; i++)
+                    {
+                        // Force RGB clone — keeps weiß-as-white so the transparency map matches at re-add time.
+                        images[i] = new Bitmap(il.Images[i]);
+                        keys[i] = il.Images.Keys[i];
+                    }
+                    il.Images.Clear();
+                    il.TransparentColor = Color.White;
+                    for (int i = 0; i < count; i++)
+                    {
+                        if (!string.IsNullOrEmpty(keys[i]))
+                            il.Images.Add(keys[i], images[i]);
+                        else
+                            il.Images.Add(images[i]);
+                    }
+                    _ilDarkApplied.Add(il);
+                }
+                catch
+                {
+                    // If anything fails (e.g. another thread holding the list), leave it as-is rather
+                    // than risk a half-rebuilt ImageList that breaks ImageIndex references.
+                }
+            }
+            // Note: we never undo the dark-mode rebuild on theme-switch back to light — that would
+            // require keeping pristine originals around. Acceptable: light-mode white-icons-on-white
+            // are visually OK with TransparentColor=White (no white-frame artifact).
+        }
+
+        private static void TreeView_DrawNode(object sender, DrawTreeNodeEventArgs e)
+        {
+            if (!Theme.IsDark || e.Node == null) { e.DrawDefault = true; return; }
+            bool selected = (e.State & TreeNodeStates.Selected) == TreeNodeStates.Selected;
+            if (!selected) { e.DrawDefault = true; return; }
+            var tv = (TreeView)sender;
+            var font = e.Node.NodeFont ?? tv.Font;
+            using (var bg = new SolidBrush(Theme.Accent))
+                e.Graphics.FillRectangle(bg, e.Bounds);
+            TextRenderer.DrawText(e.Graphics, e.Node.Text, font, e.Bounds, Theme.FgPrimary,
+                TextFormatFlags.GlyphOverhangPadding | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
+            // We painted everything in e.Bounds — override DrawDefault that the prior designer-time
+            // handler may have set, so the OS doesn't draw on top of us.
+            e.DrawDefault = false;
+        }
+
+        // ---- ListView (Details view: header + zebra/severity backgrounds) ----------
+
+        private static void ApplyListView(ListView lv)
+        {
+            lv.BackColor = Theme.BgInput;
+            lv.ForeColor = Theme.FgPrimary;
+            if (Theme.IsDark)
+            {
+                lv.BorderStyle = BorderStyle.FixedSingle;
+                if (!_lvHandlers.Contains(lv))
+                {
+                    lv.OwnerDraw = true;
+                    lv.DrawColumnHeader += ListView_DrawColumnHeader;
+                    lv.DrawItem += ListView_DrawItem;
+                    lv.DrawSubItem += ListView_DrawSubItem;
+                    _lvHandlers.Add(lv);
+                }
+            }
+            else
+            {
+                lv.BorderStyle = BorderStyle.Fixed3D;
+                // OwnerDraw handlers are stable across theme switches — keep them attached;
+                // they early-out when !Theme.IsDark via DrawDefault.
+            }
+            TryDarkenNative(lv);
+        }
+
+        private static void ListView_DrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        {
+            if (!Theme.IsDark) { e.DrawDefault = true; return; }
+            using (var bg = new SolidBrush(Theme.BgPanel))
+                e.Graphics.FillRectangle(bg, e.Bounds);
+            using (var pen = new Pen(Theme.Border))
+                e.Graphics.DrawRectangle(pen, e.Bounds.X, e.Bounds.Y, e.Bounds.Width - 1, e.Bounds.Height - 1);
+            var textRect = new Rectangle(e.Bounds.X + 4, e.Bounds.Y, e.Bounds.Width - 8, e.Bounds.Height);
+            TextRenderer.DrawText(e.Graphics, e.Header.Text, e.Font, textRect, Theme.FgPrimary,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding | TextFormatFlags.EndEllipsis);
+        }
+
+        private static void ListView_DrawItem(object sender, DrawListViewItemEventArgs e)
+        {
+            if (!Theme.IsDark) { e.DrawDefault = true; return; }
+            var lv = (ListView)sender;
+            // In Details view, DrawSubItem renders each cell. Only handle non-Details here.
+            if (lv.View == View.Details)
+            {
+                return;
+            }
+            bool selected = (e.State & ListViewItemStates.Selected) != 0;
+            var bgColor = selected ? Theme.Accent : Theme.BgInput;
+            using (var bg = new SolidBrush(bgColor))
+                e.Graphics.FillRectangle(bg, e.Bounds);
+            TextRenderer.DrawText(e.Graphics, e.Item.Text, e.Item.Font, e.Bounds, Theme.FgPrimary,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+        }
+
+        // Find a severity color in the item's subitems (e.g. INFO-blue / WARN-orange / CRIT-red
+        // set as SubItem.BackColor in SearchErrorsForm). Returns Color.Empty if none.
+        private static Color FindSeverityColor(ListViewItem item)
+        {
+            if (item == null) return Color.Empty;
+            for (int i = 0; i < item.SubItems.Count; i++)
+            {
+                var sub = item.SubItems[i];
+                var bg = sub.BackColor;
+                if (bg.A == 0) continue;
+                // Light-mode defaults (white / zebra-light grey) are not severity markers.
+                bool isLight = bg == Color.White || (bg.R >= 220 && bg.G >= 220 && bg.B >= 220);
+                if (isLight) continue;
+                return bg;
+            }
+            return Color.Empty;
+        }
+
+        private static void ListView_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            if (!Theme.IsDark) { e.DrawDefault = true; return; }
+            // Use the framework's authoritative Selected property — e.ItemState is unreliable on
+            // ListViews with FullRowSelect=true + HideSelection=false; it can report Selected for
+            // unselected rows, which made every row paint as if selected.
+            bool selected = e.Item != null && e.Item.Selected;
+
+            // All cells get the same uniform background — no per-column severity fill.
+            Color bgColor = selected ? Theme.Accent : Theme.BgInput;
+            using (var bg = new SolidBrush(bgColor))
+                e.Graphics.FillRectangle(bg, e.Bounds);
+
+            int textIndent = 4;
+            if (e.ColumnIndex == 0)
+            {
+                // Severity stripe: drawn always on column 0, regardless of selection. For selected
+                // rows we still want the severity visible (the accent bg is behind, stripe overlays).
+                var severity = FindSeverityColor(e.Item);
+                if (!severity.IsEmpty)
+                {
+                    using (var stripe = new SolidBrush(severity))
+                        e.Graphics.FillRectangle(stripe, e.Bounds.X, e.Bounds.Y, 4, e.Bounds.Height);
+                    textIndent = 8;
+                }
+            }
+
+            // SubItem.ForeColor is often Color.Black (caller never sets it), unreadable on dark.
+            var pad = new Rectangle(e.Bounds.X + textIndent, e.Bounds.Y,
+                Math.Max(0, e.Bounds.Width - textIndent - 4), e.Bounds.Height);
+            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, e.SubItem.Font ?? e.Item.Font, pad, Theme.FgPrimary,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+        }
+
+        // ---- Disabled-state overlays (Button / CheckBox / RadioButton) -------------
+
+        private static void Button_EnabledChanged(object sender, EventArgs e) { ((Control)sender).Invalidate(); }
+        private static void CheckBox_EnabledChanged(object sender, EventArgs e) { ((Control)sender).Invalidate(); }
+        private static void RadioButton_EnabledChanged(object sender, EventArgs e) { ((Control)sender).Invalidate(); }
+        private static void Label_EnabledChanged(object sender, EventArgs e) { ((Control)sender).Invalidate(); }
+
+        private static TextFormatFlags AlignToFlags(ContentAlignment a)
+        {
+            TextFormatFlags f = TextFormatFlags.NoPadding;
+            switch (a)
+            {
+                case ContentAlignment.TopLeft:      f |= TextFormatFlags.Top    | TextFormatFlags.Left; break;
+                case ContentAlignment.TopCenter:    f |= TextFormatFlags.Top    | TextFormatFlags.HorizontalCenter; break;
+                case ContentAlignment.TopRight:     f |= TextFormatFlags.Top    | TextFormatFlags.Right; break;
+                case ContentAlignment.MiddleLeft:   f |= TextFormatFlags.VerticalCenter | TextFormatFlags.Left; break;
+                case ContentAlignment.MiddleCenter: f |= TextFormatFlags.VerticalCenter | TextFormatFlags.HorizontalCenter; break;
+                case ContentAlignment.MiddleRight:  f |= TextFormatFlags.VerticalCenter | TextFormatFlags.Right; break;
+                case ContentAlignment.BottomLeft:   f |= TextFormatFlags.Bottom | TextFormatFlags.Left; break;
+                case ContentAlignment.BottomCenter: f |= TextFormatFlags.Bottom | TextFormatFlags.HorizontalCenter; break;
+                case ContentAlignment.BottomRight:  f |= TextFormatFlags.Bottom | TextFormatFlags.Right; break;
+            }
+            return f;
+        }
+
+        private static void Label_PaintDisabledOverlay(object sender, PaintEventArgs e)
+        {
+            if (!Theme.IsDark) return;
+            var lbl = (Label)sender;
+            if (lbl.Enabled) return;
+
+            Color bgColor = lbl.BackColor;
+            if (bgColor == Color.Transparent || bgColor.A == 0)
+                bgColor = lbl.Parent != null ? lbl.Parent.BackColor : Theme.BgPanel;
+
+            using (var bg = new SolidBrush(bgColor))
+                e.Graphics.FillRectangle(bg, lbl.ClientRectangle);
+
+            TextRenderer.DrawText(e.Graphics, lbl.Text, lbl.Font, lbl.ClientRectangle,
+                _dDisabledFg, AlignToFlags(lbl.TextAlign));
+        }
+
+        private static void Button_PaintDisabledOverlay(object sender, PaintEventArgs e)
+        {
+            if (!Theme.IsDark) return;
+            var b = (Button)sender;
+            if (b.Enabled) return;
+            var g = e.Graphics;
+            using (var bg = new SolidBrush(Theme.BgPanel))
+                g.FillRectangle(bg, 0, 0, b.Width, b.Height);
+            using (var pen = new Pen(Theme.Border))
+                g.DrawRectangle(pen, 0, 0, b.Width - 1, b.Height - 1);
+            TextRenderer.DrawText(g, b.Text, b.Font, b.ClientRectangle, _dDisabledFg,
+                TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter);
+        }
+
+        private static void CheckBox_PaintDisabledOverlay(object sender, PaintEventArgs e)
+        {
+            if (!Theme.IsDark) return;
+            var cb = (CheckBox)sender;
+            if (cb.Enabled) return;
+            // Glyph occupies roughly the first 14-16px; overdraw only the text area to keep glyph intact.
+            int glyphArea = 16;
+            int textX = glyphArea;
+            int textW = Math.Max(0, cb.Width - textX);
+            var textRect = new Rectangle(textX, 0, textW, cb.Height);
+            using (var bg = new SolidBrush(cb.BackColor))
+                e.Graphics.FillRectangle(bg, textRect);
+            TextRenderer.DrawText(e.Graphics, cb.Text, cb.Font, textRect, _dDisabledFg,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding | TextFormatFlags.WordBreak);
+        }
+
+        private static void RadioButton_PaintDisabledOverlay(object sender, PaintEventArgs e)
+        {
+            if (!Theme.IsDark) return;
+            var rb = (RadioButton)sender;
+            if (rb.Enabled) return;
+            int glyphArea = 16;
+            int textX = glyphArea;
+            int textW = Math.Max(0, rb.Width - textX);
+            var textRect = new Rectangle(textX, 0, textW, rb.Height);
+            using (var bg = new SolidBrush(rb.BackColor))
+                e.Graphics.FillRectangle(bg, textRect);
+            TextRenderer.DrawText(e.Graphics, rb.Text, rb.Font, textRect, _dDisabledFg,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding | TextFormatFlags.WordBreak);
         }
 
         private static void GroupBox_Paint(object sender, PaintEventArgs e)
@@ -261,7 +717,8 @@ namespace SpacerUnion.Common
                 {
                     g.FillRectangle(bg, textRect);
                 }
-                using (var fg = new SolidBrush(gb.ForeColor))
+                Color titleColor = gb.Enabled ? gb.ForeColor : _dDisabledFg;
+                using (var fg = new SolidBrush(titleColor))
                 {
                     g.DrawString(gb.Text, gb.Font, fg, 8, 0);
                 }
@@ -275,10 +732,14 @@ namespace SpacerUnion.Common
             var tc = (TabControl)sender;
             var g = e.Graphics;
 
-            // 1. Fill the tab strip background (the strip behind/between tab headers, plus margins around the page area)
+            // 1. Fill the FULL control rectangle, NOT tc.ClientRectangle — for TabControl, ClientRectangle
+            //    excludes the tab strip and a sliver of border around the TabPage area on most Windows
+            //    versions, leaving white slivers behind the headers and around the page perimeter.
+            //    TabPages overdraw their own area afterwards (see TabPage branch in ApplyToControl), so
+            //    over-fill here is harmless.
             using (var bg = new SolidBrush(Theme.BgPanel))
             {
-                g.FillRectangle(bg, tc.ClientRectangle);
+                g.FillRectangle(bg, 0, 0, tc.Width, tc.Height);
             }
 
             // 2. Draw each tab header on top

--- a/SpacerNET_Interface/Windows/MaterialFilterForm.cs
+++ b/SpacerNET_Interface/Windows/MaterialFilterForm.cs
@@ -40,6 +40,7 @@ namespace SpacerUnion.Windows
             filderIndexToSaveList = new List<int>();
             foundMatList = new Dictionary<string, int>();
             formConf = new ConfirmForm(null);
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(formConf);
             textBoxTexName.BackColor = textBoxTexName.BackColor;
         }
 

--- a/SpacerNET_Interface/Windows/ObjectsWin.cs
+++ b/SpacerNET_Interface/Windows/ObjectsWin.cs
@@ -56,6 +56,7 @@ namespace SpacerUnion
             comboBoxSphereType.SelectedIndex = 0;
             camEntry = new CameraKeyEntry(this);
             formConf = new ConfirmForm(null);
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(formConf);
             spawnListData = new Dictionary<string, List<string>>();
             pathFile = Path.GetFullPath(@"../_work/tools/spawnlist_spacernet.txt");
         }

--- a/SpacerNET_Interface/Windows/PFXEditorWin.cs
+++ b/SpacerNET_Interface/Windows/PFXEditorWin.cs
@@ -40,6 +40,7 @@ namespace SpacerUnion.Windows
             Helper.EnableDoubleBuffering(this.treeViewPFX);
 
             formConf = new ConfirmForm(null);
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(formConf);
             ToggleInterface(false);
 
             

--- a/SpacerNET_Interface/Windows/VobCatalog.cs
+++ b/SpacerNET_Interface/Windows/VobCatalog.cs
@@ -31,6 +31,11 @@ namespace SpacerUnion.Windows
             formConf = new ConfirmForm(null);
             propsForm = new VobCatalogPropsForm();
             moveForm = new VobCatalogMoveForm();
+            // Modal dialogs aren't in SpacerNET.windowsList — register so they pick up dark theme
+            // (postm1 feedback 2026-05-15: Vob Catalog Add/Edit + Add-new-group were white).
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(formConf);
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(propsForm);
+            SpacerUnion.Common.ThemeApplier.RegisterDialog(moveForm);
 
             pathFile = Path.GetFullPath(@"../_work/tools/vobcatalog_spacernet.txt");
             pathFileCopy = Path.GetFullPath(@"../_work/tools/vobcatalog_spacernet_backup.txt");


### PR DESCRIPTION
## Summary

Follow-up to your review comments on #26 — addresses the visual bugs you found after the merge to master. Force-pushed today (2026-05-21) with additional fixes for your screenshot feedback from 2026-05-15.

Two passes in this branch, history is amended into a single commit:

**Pass 1 (original PR content):** disabled-state readability + DataGridView/ListView/ComboBox skinning.
**Pass 2 (new, on top):** Search-errors row visibility, TreeView selection, ImageList icon transparency, modal dialog theming.

## What was unreadable / off (Pass 1)

| Where | Before | After |
|---|---|---|
| Disabled buttons (Apply/BBox/Container in Properties, Jump-to-key + Remove-all in Triggers, etc.) | WinForms drew text with `SystemColors.GrayText` → grey-on-grey | Paint overlay redraws text in `Color(165,165,165)` on `!Enabled` |
| Disabled checkboxes (Highlight selected vob type, Show keys visually, Make some vob's fields…) | same problem | same fix applied to `CheckBox`, `RadioButton`, `Label` |
| Disabled labels in disabled GroupBox (e.g. `Set filter:` / `Set group:` when `groupBoxMatSettings.Enabled = false`) | greyed out, near-invisible | covered by the label overlay |
| Disabled GroupBox titles | greyed out | `GroupBox_Paint` now uses `_dDisabledFg` when `gb.Enabled == false` |
| `DataGridView` (Keys binding, Properties items tab) | white `BackgroundColor`, visual-style headers | full skin: `BackgroundColor`, `GridColor`, `EnableHeadersVisualStyles=false`, all three `DefaultCellStyle`s |
| `ListView` (Search errors in ZEN) — initial pass | white headers + rows ignored theme | `OwnerDraw=true`, custom header/item/sub-item handlers |
| `ComboBox` (DropDownList style) | BackColor ignored by WinForms, drop-down button light-grey | `DrawMode=OwnerDrawFixed` + custom `DrawItem` for items; `SetWindowTheme(handle, \"DarkMode_CFD\")` so the chevron button matches on Win10/11 |
| Light-grey buttons in Light/Camera tabs of Objects Window | `BackColor` was set before clearing `UseVisualStyleBackColor`, so WinForms discarded the BackColor | Order reversed: `UseVisualStyleBackColor=false` first, then `BackColor` |

## New since your screenshot feedback (Pass 2)

| Issue (from your screenshots) | Cause | Fix |
|---|---|---|
| **Search errors ListView — every row looked selected** | Severity colors (INFO-blue / WARN-orange / CRIT-red) filled the whole row at full saturation, drowning out the actual selection. Plus `e.ItemState` reported every row as selected when `FullRowSelect=true` + `HideSelection=false`. | Uniform dark BG + 4px left severity stripe. Authoritative selection uses `e.Item.Selected` instead of the bitmask. |
| **TreeView selection invisible between colored type icons** (vob property tree + Spacer-vobs tree) | Default `TreeViewDrawMode.Normal` lets the OS draw a subtle selection bg that gets lost between bright ImageList icons. | In dark mode the TreeView switches to `OwnerDrawText` with a strong `Theme.Accent` fill for the selected node. Designer-time `DrawNode` handlers still fire but ours runs after them and overpaints. |
| **TreeView ImageList icons framed in white** (selWP, imgClass16x16, etc.) | Designer set `TransparentColor=Transparent` but the icons were embedded as 8bit/24bit with a literal white backdrop, where `Transparent` is a no-op. | Snapshot existing images, clear list, set `TransparentColor=White`, re-add. `TransparentColor` is only honored at add-time, so re-add turns the white backdrop transparent. |
| **Modal dialogs in Vob Catalog + ConfirmForm everywhere were white** | The modals (`formConf`, `propsForm`, `moveForm`) are not in `SpacerNET.windowsList` so the global `ApplyAll` pass skipped them. | `ThemeApplier.RegisterDialog(Form)` tracks them; `ReapplyRegisteredDialogs` runs on theme switch. Registered in `Macros.cs`, `MaterialFilterForm.cs`, `ObjectsWin.cs`, `PFXEditorWin.cs`, `VobCatalog.cs`. |

## Known limitation — TabControl body border

The white 3D groove around the TabPage area is still there in dark mode. Tried in this branch and reverted because none of it worked:

- `Paint`-event overdraw with `FillRectangle(0, 0, tc.Width, tc.Height)` — WinForms draws the groove after our Paint fires, outside the Paint event path.
- `SetWindowTheme(handle, \"\", \"\")` — TabControl renders the border itself, not via Visual Styles.
- `TabAppearance.FlatButtons` — flattens the headers (Win98 look) but doesn't touch the groove.

The clean fix is a `NativeWindow` subclass that intercepts `WM_PAINT` for the TabControl. That's a larger, more invasive change with its own risk surface (subclass lifetime, dispose timing, multi-monitor DPI), so I'd like to ask before adding it: **should I follow up with a NativeWindow subclass for TabControl, or leave the white groove as-is for now?**

## Light mode unaffected

Every new code path guards on `Theme.IsDark`. The Paint overlays early-out, the DataGridView/ListView/TreeView branches reset their light-mode defaults, and `SetWindowTheme(handle, null, null)` clears the dark sub-theme. The ImageList rebuild only runs in dark mode and isn't undone on theme-switch (acceptable — light-mode-white on light-mode-window is visually correct, just with a different transparency mask).

## Test plan

Pass 1 checks (regression):

- [ ] Open with Dark Mode off → no visual change
- [ ] Enable Dark Mode in Misc Settings → Apply → all controls re-themed
- [ ] Disabled buttons / checkboxes / labels readable in Properties, Triggers, Misc Settings, VobList, Materials filter
- [ ] Keys binding DataGridView dark
- [ ] Light + Camera tab buttons dark, not light-grey
- [ ] ComboBox drop-downs dark
- [ ] **Materials filter** → no world loaded → `Set filter:` / `Set group:` labels readable

Pass 2 checks (new):

- [x] **Search errors in ZEN** → load a world → Find all errors → rows have uniform dark BG with a 4px stripe on the left (red Critical / orange Warning / light-blue Info). Selecting a row shows the accent color across the row, the severity stripe stays visible.
- [x] **Properties window → Vob tree (treeViewProp)** → click a property → selection is clearly accent-colored, ImageList icons next to each row no longer have a white backdrop
- [x] **Objects list window (classesTreeView)** → click an entry → selection clearly visible; red waypoint icons no longer have a white frame
- [x] **Vob Catalog → Add new / Edit / Add new group** → dialogs open with dark theme
- [x] **ConfirmForm dialogs everywhere** (Macros / MaterialFilter / Objects / PFXEditor / VobCatalog) → dark on first open + after theme switch